### PR TITLE
fix: :bug: correct the typo in ModuleStyles file

### DIFF
--- a/app/styles/DefaultModuleStyles.js
+++ b/app/styles/DefaultModuleStyles.js
@@ -7,7 +7,7 @@ export default class DefaultModuleStyles extends DefaultCoreStyles {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/LargeModuleStyles.js
+++ b/app/styles/LargeModuleStyles.js
@@ -7,7 +7,7 @@ export default class LargeModuleStyles extends LargeCoreStyles {
       /**************************************************
        * Using LargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/MediumModuleStyles.js
+++ b/app/styles/MediumModuleStyles.js
@@ -7,7 +7,7 @@ export default class MediumModuleStyles extends MediumCoreStyles {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/SmallModuleStyles.js
+++ b/app/styles/SmallModuleStyles.js
@@ -7,7 +7,7 @@ export default class SmallModuleStyles extends SmallCoreStyles {
       /**************************************************
        * Using smallUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XLargeModuleStyles.js
+++ b/app/styles/XLargeModuleStyles.js
@@ -7,7 +7,7 @@ export default class XLargeModuleStyles extends XLargeCoreStyles {
       /**************************************************
        * Using XLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XXLargeModuleStyles.js
+++ b/app/styles/XXLargeModuleStyles.js
@@ -7,7 +7,7 @@ export default class XXLargeModuleStyles extends XXLargeCoreStyles {
       /**************************************************
        * Using XXLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }


### PR DESCRIPTION

## Description
correct the typo in ModuleStyles file in following /DefaultModuleStyles.js /LargeModuleStyles.js /MediumModuleStyles.js  /SmallModuleStyles.js   /XLargeModuleStyles.js  /XXLargeModuleStyles.js correct styles to style

ref: #19

